### PR TITLE
bugfix Load only my events

### DIFF
--- a/src/app/layout/my-events/my-events.component.ts
+++ b/src/app/layout/my-events/my-events.component.ts
@@ -65,7 +65,7 @@ export class MyEventsComponent implements OnInit {
       size: this.pageSize
     };
 
-    this.eventService.getAll(filters).subscribe({
+    this.eventService.getAllMine(filters).subscribe({
       next: (paged: PagedModel<Event>) => {
         this.myEvents = paged.content;
         this.totalEvents = paged.page.totalElements;

--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -53,6 +53,11 @@ export class EventService {
     return this.httpClient.get<PagedModel<Event>>(this.apiUrl, { params });
   }
 
+  getAllMine(filters?: EventFilterParams): Observable<PagedModel<Event>> {
+    const params = buildHttpParams(filters)
+    return this.httpClient.get<PagedModel<Event>>(this.apiUrl + "/mine", { params });
+  }
+
   getAllSummaries(filters?: EventFilterParams): Observable<PagedModel<EventSummaryDto>> {
     const params = buildHttpParams(filters)
     return this.httpClient.get<PagedModel<EventSummaryDto>>(this.apiUrl + "/summaries", { params });


### PR DESCRIPTION
This pull request updates the way "My Events" are fetched in the application to use a dedicated API endpoint, ensuring users only see events associated with their account. The main changes include adding a new service method and updating the component to use it.

**Feature: Fetching personal events**

* Added a new method `getAllMine` to the `EventService` that calls the `/mine` endpoint, ensuring only the current user's events are retrieved.
* Updated `MyEventsComponent` to use the new `getAllMine` method instead of the generic `getAll`, so it displays only the user's own events.